### PR TITLE
Create DatastoreService and prepare pom.xml for deploying to the live site.

### DIFF
--- a/sentimental/pom.xml
+++ b/sentimental/pom.xml
@@ -12,11 +12,11 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>
-    <googleCloudProjectId>YOUR_PROJECT_ID_HERE</googleCloudProjectId>
+    <googleCloudProjectId>spring21-sps-37</googleCloudProjectId>
   </properties>
 
   <dependencies>
@@ -38,11 +38,19 @@
       <artifactId>jetty-annotations</artifactId>
       <version>${jetty.version}</version>
     </dependency>
+
     <!-- Twitter API -->
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
       <version>[4.0,)</version>
+    </dependency>
+
+    <!-- Datastore -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+      <version>1.104.0</version>
     </dependency>
   </dependencies>
 

--- a/sentimental/src/main/java/com/google/sps/data/DatastoreService.java
+++ b/sentimental/src/main/java/com/google/sps/data/DatastoreService.java
@@ -1,0 +1,55 @@
+package com.google.sps.data;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DatastoreService {
+
+  /** Returns a List of all of the Tweets stored in Datastore, newest first. */
+  public List<Tweet> getAllTweets() {
+    Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
+    Query<Entity> query =
+      Query.newEntityQueryBuilder().setKind("Tweet").setOrderBy(OrderBy.desc("timestamp")).build();
+    QueryResults<Entity> results = datastore.run(query);
+
+    List<Tweet> tweets = new ArrayList<>();
+    while (results.hasNext()) {
+      Entity entity = results.next();
+
+      long id = entity.getKey().getId();
+      String text = entity.getString("text");
+      long timestamp = entity.getLong("timestamp");
+
+      Tweet tweet = new Tweet(id, text, timestamp);
+      tweets.add(tweet);
+    }
+
+    return tweets;
+  }
+
+  /**
+   * Saves the Tweets in Datastore. Tweets with duplicate IDs will not be
+   * repeated, so this is safe to call with the same Tweets multiple times.
+   */
+  public void saveTweets(List<Tweet> tweets) {
+    Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
+    KeyFactory keyFactory = datastore.newKeyFactory().setKind("Tweet");
+
+    for (Tweet tweet : tweets) {
+      FullEntity taskEntity =
+          Entity.newBuilder(keyFactory.newKey(tweet.getID()))
+              .set("text", tweet.getText())
+              .set("timestamp", tweet.getTimestamp())
+              .build();
+      datastore.put(taskEntity);
+    }
+  }
+}

--- a/sentimental/src/main/java/com/google/sps/servlets/DatastoreDebugServlet.java
+++ b/sentimental/src/main/java/com/google/sps/servlets/DatastoreDebugServlet.java
@@ -1,0 +1,50 @@
+package com.google.sps.servlets;
+
+import com.google.sps.data.DatastoreService;
+import com.google.sps.data.Tweet;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Prints a table of Tweets stored in Datastore, used for debugging. */
+@WebServlet("/datastore-debug")
+public class DatastoreDebugServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+
+    // Store some fake tweets for testing.
+    // NOTE: We probably want to delete this before we deploy this code to the
+    // live site!
+    List<Tweet> input = new ArrayList<>();
+    input.add(new Tweet(1, "hello", 1000));
+    input.add(new Tweet(2, "abc", 2000));
+    input.add(new Tweet(3, "xyz", 3000));
+
+    DatastoreService datastoreService = new DatastoreService();
+    datastoreService.saveTweets(input);
+
+    List<Tweet> output = datastoreService.getAllTweets();
+
+    response.setContentType("text/html;");
+    response.getWriter().println("<table>");
+    response.getWriter().println("<tr>");
+    response.getWriter().println("<th>ID</th>");
+    response.getWriter().println("<th>Text</th>");
+    response.getWriter().println("<th>Timestamp</th>");
+    response.getWriter().println("</tr>");
+    for(Tweet tweet : output) {
+      response.getWriter().println("<tr>");
+      response.getWriter().println("<td>" + tweet.getID() + "</td>");
+      response.getWriter().println("<td>" + tweet.getText() + "</td>");
+      response.getWriter().println("<td>" + tweet.getTimestamp() + "</td>");
+      response.getWriter().println("</tr>");
+    }
+    response.getWriter().println("</table>");
+  }
+}


### PR DESCRIPTION
I added a `DatastoreService` class that handles saving and loading Tweets using Datastore.

The idea is that after we fetch the tweets, we can call the `saveTweets()` function to save the tweets. And then to build the visualizations, we can call the `loadAllTweets()` function to load the tweets from Datastore, without needing to query Twitter again.

I also added a `DatastoreDebugServlet` class that let me test this code out, both locally and on the live site. It seems to work!

Note that to run locally, you'll now need to do four things:

1. Run this command: `gcloud beta emulators datastore start`
2. Find the line in the output that says something like `export DATASTORE_EMULATOR_HOST=localhost:8081`
3. In a **new** console tab, paste that command and hit enter.
4. In that second console tab, run this command: `mvn package exec:java`

We need to do this because this runs a local version of Datastore, which the local version of App Engine will then use.

I also modified `pom.xml` so that we can now deploy to the live server.